### PR TITLE
Implement UI for complete/incomplete buttons on chords tab 

### DIFF
--- a/443-Chordable/Views/Tabs/ChordsView.swift
+++ b/443-Chordable/Views/Tabs/ChordsView.swift
@@ -96,11 +96,32 @@ struct ChordsView: View {
                         )
                       }
                   }
-                }.padding([.leading, .trailing])
+                }
+                .padding([.leading, .trailing])
+                
+                // underline for buttons when pressed 
+                Spacer()
+                  GeometryReader { geometry in
+                    HStack {
+                      Rectangle()
+                      .fill(viewController.filterOnCompleted ?
+                          AnyShapeStyle(LinearGradient(gradient: Gradient(colors: [Color(red: 36 / 255.0, green: 0, blue: 255 / 255.0), Color(red: 127 / 255.0, green: 0, blue: 255 / 255.0)]), startPoint: .leading, endPoint: .trailing)) :
+                          AnyShapeStyle(Color.clear)
+                      )
+                      .frame(width: geometry.size.width / 2, height: 5)
+                      Spacer()
+                      Rectangle()
+                      .fill(!viewController.filterOnCompleted ?
+                          AnyShapeStyle(LinearGradient(gradient: Gradient(colors: [Color(red: 36 / 255.0, green: 0, blue: 255 / 255.0), Color(red: 127 / 255.0, green: 0, blue: 255 / 255.0)]), startPoint: .leading, endPoint: .trailing)) :
+                          AnyShapeStyle(Color.clear)
+                      )
+                      .frame(width: geometry.size.width / 2, height: 5)
+                    }
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                  }.padding(.bottom, -15)
               }
             }
           }
-          .padding(.vertical, 20)
            
           VStack{
             VStack{
@@ -154,7 +175,7 @@ struct ChordsView: View {
               }
               Spacer()
             }.padding(.bottom, 40)
-            .frame(minHeight: 430)
+            .frame(minHeight: 460)
           }
           .background(Color(red: 35 / 255.0, green: 35 / 255.0, blue: 35 / 255.0))
         }

--- a/443-Chordable/Views/Tabs/ChordsView.swift
+++ b/443-Chordable/Views/Tabs/ChordsView.swift
@@ -36,25 +36,24 @@ struct ChordsView: View {
                     viewController.filterOnCompleted = true
                   }) {
                     Text("Completed")
-                      .padding()
-                      .background(viewController.filterOnCompleted ? Color.blue : Color.gray)
-                      .foregroundColor(.white)
-                      .cornerRadius(8)
+                      .foregroundColor(viewController.filterOnCompleted ? Color(red: 0.63, green: 0.63, blue: 0.63) : .white)
+                      .font(viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 20) : .custom("Barlow-Regular", size: 22))
+                      .padding(.trailing, 50)
                   }
                   
                   Button(action: {
                     viewController.filterOnCompleted = false
                   }) {
                     Text("Incomplete")
-                      .padding()
-                      .background(viewController.filterOnCompleted ? Color.gray : Color.blue)
-                      .foregroundColor(.white)
-                      .cornerRadius(8)
+                      .foregroundColor(!viewController.filterOnCompleted ? Color(red: 0.63, green: 0.63, blue: 0.63) : .white)
+                      .font(viewController.filterOnCompleted ? .custom("Barlow-Regular", size: 20) : .custom("Barlow-Bold", size: 22))
+                      .padding(.leading, 50)
                   }
                 }.padding([.leading, .trailing])
               }
             }
-          }.padding(.top, 20)
+          }
+          .padding(.vertical, 20)
            
           VStack{
             VStack{

--- a/443-Chordable/Views/Tabs/ChordsView.swift
+++ b/443-Chordable/Views/Tabs/ChordsView.swift
@@ -10,6 +10,7 @@ struct ChordsView: View {
           VStack {
             Text("CHORDS")
               .padding(.top,30)
+              .padding(.bottom, 10)
               .font(.custom("Barlow-Bold", size: 32))
               .frame(maxWidth: .infinity, alignment: .leading)
               .kerning(1.6)
@@ -99,7 +100,7 @@ struct ChordsView: View {
                 }
                 .padding([.leading, .trailing])
                 
-                // underline for buttons when pressed 
+                // underline for buttons when pressed
                 Spacer()
                   GeometryReader { geometry in
                     HStack {

--- a/443-Chordable/Views/Tabs/ChordsView.swift
+++ b/443-Chordable/Views/Tabs/ChordsView.swift
@@ -28,26 +28,73 @@ struct ChordsView: View {
                 .frame(height: 5)
                 .padding(.horizontal, 30)
 
+              // styling for searchbar & complete/incomplete buttons
               VStack {
                 SearchBar(text: $viewController.searchQuery)
                 
                 HStack {
+                  // button styling for complete
                   Button(action: {
                     viewController.filterOnCompleted = true
                   }) {
                     Text("Completed")
-                      .foregroundColor(viewController.filterOnCompleted ? Color(red: 0.63, green: 0.63, blue: 0.63) : .white)
-                      .font(viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 20) : .custom("Barlow-Regular", size: 22))
+                      .font(viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 22) : .custom("Barlow-Regular", size: 22))
                       .padding(.trailing, 50)
+                      .overlay { viewController.filterOnCompleted ?
+                        LinearGradient(
+                          colors: [Color(red: 36 / 255, green: 0, blue: 255 / 255), Color(red: 127 / 255, green: 0, blue: 255 / 255)],
+                          startPoint: .leading,
+                          endPoint: .trailing
+                        )
+                        .mask(
+                          Text("Completed")
+                          .font(viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 22) : .custom("Barlow-Regular", size: 22))
+                          .padding(.trailing, 50)
+                        )
+                        :
+                        LinearGradient(
+                          colors: [Color(red: 0.63, green: 0.63, blue: 0.63), Color(red: 0.63, green: 0.63, blue: 0.63)],
+                          startPoint: .leading,
+                          endPoint: .trailing
+                        )
+                        .mask(
+                          Text("Completed")
+                          .font(viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 22) : .custom("Barlow-Regular", size: 22))
+                          .padding(.trailing, 50)
+                        )
+                      }
                   }
                   
+                  // button styling for incomplete
                   Button(action: {
                     viewController.filterOnCompleted = false
                   }) {
                     Text("Incomplete")
-                      .foregroundColor(!viewController.filterOnCompleted ? Color(red: 0.63, green: 0.63, blue: 0.63) : .white)
-                      .font(viewController.filterOnCompleted ? .custom("Barlow-Regular", size: 20) : .custom("Barlow-Bold", size: 22))
+                      .font(viewController.filterOnCompleted ? .custom("Barlow-Regular", size: 22) : .custom("Barlow-Bold", size: 22))
                       .padding(.leading, 50)
+                      .overlay { !viewController.filterOnCompleted ?
+                        LinearGradient(
+                          colors: [Color(red: 36 / 255, green: 0, blue: 255 / 255), Color(red: 127 / 255, green: 0, blue: 255 / 255)],
+                          startPoint: .leading,
+                          endPoint: .trailing
+                        )
+                        .mask(
+                          Text("Incomplete")
+                          .font(!viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 22) : .custom("Barlow-Regular", size: 22))
+                          .padding(.leading, 50)
+                        )
+                        :
+                        LinearGradient(
+                          colors: [Color(red: 0.63, green: 0.63, blue: 0.63), Color(red: 0.63, green: 0.63, blue: 0.63)],
+                          startPoint: .leading,
+                          endPoint: .trailing
+                        )
+                        .mask(
+                          Text("Incomplete")
+                          .font(!viewController.filterOnCompleted ? .custom("Barlow-Bold", size: 22) : .custom("Barlow-Regular", size: 22))
+                          .padding(.leading, 50)
+                        )
+                      }
                   }
                 }.padding([.leading, .trailing])
               }


### PR DESCRIPTION
Implement styling for complete/incomplete buttons on the chords tab. 
Closes #45 
![Simulator Screenshot - iPhone 15 Pro - 2023-11-04 at 01 04 47](https://github.com/arielkwak/67-443-Project/assets/82299804/e4dde249-00b2-4987-8a77-58d703cf51e7)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-04 at 01 04 45](https://github.com/arielkwak/67-443-Project/assets/82299804/4b13adbd-e48d-4335-a65e-a18ed7d8927b)

